### PR TITLE
Fix update notice

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -2,7 +2,7 @@
 	<update>
 		<name>plg_cccsocialmedia</name>
 		<description>Joomla Plugin to display Open Graph and Twitter Options in your menu items and articles</description>
-		<element>plg_cccsocialmedia</element>
+		<element>cccsocialmedia</element>
 		<type>plugin</type>
 		<client>site</client>
 		<folder>system</folder>

--- a/manifest.xml
+++ b/manifest.xml
@@ -5,6 +5,7 @@
 		<element>plg_cccsocialmedia</element>
 		<type>plugin</type>
 		<client>site</client>
+		<folder>system</folder>
 		<version>2.0.1</version>
 		<downloads>
 			<downloadurl type="full" format="zip">https://github.com/coolcat-creations/plg_cccsocialmedia/releases/download/v2.0.1/plg_cccsocialmedia.zip</downloadurl>


### PR DESCRIPTION
Added two new lines to manifest.xml.

folder is required for plugins: https://docs.joomla.org/Deploying_an_Update_Server

Why was no update displayed?
The element name must match the entry in the database.

There is NO need to deploy a new version. These changes show updates in the Joomla instances.